### PR TITLE
Add Angle comparisons and thread-safe track IDs

### DIFF
--- a/python-port/angle.py
+++ b/python-port/angle.py
@@ -1,0 +1,84 @@
+import math
+
+class Angle:
+    """Represents an angle in radians with helpers for degree conversion."""
+
+    def __init__(self, radians: float = 0.0) -> None:
+        self.the_angle = float(radians)
+
+    @property
+    def degrees(self) -> float:
+        """Return the angle in degrees."""
+        return self.the_angle * 180.0 / math.pi
+
+    @degrees.setter
+    def degrees(self, value: float) -> None:
+        self.the_angle = float(value) * math.pi / 180.0
+
+    @staticmethod
+    def from_degrees(degrees: float) -> "Angle":
+        return Angle(degrees * math.pi / 180.0)
+
+    def __float__(self) -> float:
+        return self.the_angle
+
+    def __sub__(self, other: "Angle") -> "Angle":
+        return Angle(self.the_angle - float(other))
+
+    def __add__(self, other: "Angle") -> "Angle":
+        return Angle(self.the_angle + float(other))
+
+    def __repr__(self) -> str:
+        return f"{self.the_angle:.2f} {self.degrees:.1f}°"
+
+    # ------------------------------------------------------------------
+    # Comparison and hashing support
+    # ------------------------------------------------------------------
+
+    def _coerce(self, other) -> float | None:
+        """Return *other* as a float if possible, ``None`` otherwise."""
+        if isinstance(other, Angle):
+            return other.the_angle
+        try:
+            return float(other)
+        except (TypeError, ValueError):
+            return None
+
+    def __eq__(self, other: object) -> bool:
+        other_val = self._coerce(other)
+        if other_val is None:
+            return NotImplemented  # type: ignore[return-value]
+        return self.the_angle == other_val
+
+    def __lt__(self, other: "Angle") -> bool:
+        other_val = self._coerce(other)
+        if other_val is None:
+            return NotImplemented  # type: ignore[return-value]
+        return self.the_angle < other_val
+
+    def __le__(self, other: "Angle") -> bool:
+        other_val = self._coerce(other)
+        if other_val is None:
+            return NotImplemented  # type: ignore[return-value]
+        return self.the_angle <= other_val
+
+    def __gt__(self, other: "Angle") -> bool:
+        other_val = self._coerce(other)
+        if other_val is None:
+            return NotImplemented  # type: ignore[return-value]
+        return self.the_angle > other_val
+
+    def __ge__(self, other: "Angle") -> bool:
+        other_val = self._coerce(other)
+        if other_val is None:
+            return NotImplemented  # type: ignore[return-value]
+        return self.the_angle >= other_val
+
+    def __hash__(self) -> int:
+        return hash(self.the_angle)
+
+    def normalize(self) -> "Angle":
+        a = self.the_angle % (2 * math.pi)
+        if a < 0:
+            a += 2 * math.pi
+        return Angle(a)

--- a/python-port/colors.py
+++ b/python-port/colors.py
@@ -1,0 +1,158 @@
+"""Color utilities for the BrainSimIII Python port.
+
+This module ports a subset of the color-related helpers from
+``BrainSimulator/Utils.cs`` into Python. It provides an ``HSLColor`` class
+for converting between RGB and HSL color spaces and helpers for mapping
+color names.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import colorsys
+from typing import Dict, Tuple, List
+
+
+@dataclass
+class HSLColor:
+    """Simple representation of an HSL color.
+
+    Hue is expressed in degrees ``[0, 360)`` while saturation and luminance
+    are in the range ``[0, 1]``.
+    """
+
+    hue: float = 0.0
+    saturation: float = 0.0
+    luminance: float = 0.0
+
+    @classmethod
+    def from_rgb(cls, r: int, g: int, b: int) -> "HSLColor":
+        """Create an :class:`HSLColor` from integer RGB values."""
+        # ``colorsys`` uses the HLS convention with hue [0,1)
+        h, l, s = colorsys.rgb_to_hls(r / 255.0, g / 255.0, b / 255.0)
+        return cls(hue=h * 360.0, saturation=s, luminance=l)
+
+    def to_rgb(self) -> Tuple[int, int, int]:
+        """Return the color as integer ``(r, g, b)`` tuple."""
+        r, g, b = colorsys.hls_to_rgb(self.hue / 360.0, self.luminance, self.saturation)
+        # Use round to avoid off-by-one errors when converting back to ints
+        return round(r * 255), round(g * 255), round(b * 255)
+
+    def copy(self) -> "HSLColor":
+        return HSLColor(self.hue, self.saturation, self.luminance)
+
+    def __sub__(self, other: "HSLColor") -> float:
+        """Return a difference metric similar to the C# implementation."""
+        c1 = self.copy()
+        c2 = other.copy()
+        # whites/blacks/greys normalised to hue 0.5 as in C# code
+        if c1.luminance > 0.95 or c1.luminance < 0.1 or c1.saturation < 0.1:
+            c1.hue = 0.5
+        if c2.luminance > 0.95 or c2.luminance < 0.1 or c2.saturation < 0.1:
+            c2.hue = 0.5
+        diff = abs(c1.hue - c2.hue) * 5 + abs(c1.saturation - c2.saturation) + abs(c1.luminance - c2.luminance)
+        return diff / 7
+
+    def equals(self, other: "HSLColor") -> bool:
+        if other is None:
+            return False
+        if self.luminance < 0.05 and other.luminance < 0.05:
+            return True
+        if self.luminance > 0.95 and other.luminance > 0.95:
+            return True
+        abs_hue_diff = abs(self.hue - other.hue)
+        return abs_hue_diff < 5 or abs_hue_diff > 355
+
+
+_COLOR_MAP: Dict[str, Tuple[int, int, int]] = {
+    "black": (0, 0, 0),
+    "white": (255, 255, 255),
+    "red": (255, 0, 0),
+    "lime": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "cyan": (0, 255, 255),
+    "magenta": (255, 0, 255),
+    "orange": (255, 158, 0),
+    "silver": (192, 192, 192),
+    "gray": (128, 128, 128),
+    "maroon": (128, 0, 0),
+    "olive": (128, 128, 0),
+    "green": (0, 128, 0),
+    "purple": (128, 0, 128),
+    "teal": (0, 128, 128),
+    "navy": (0, 0, 128),
+    "azure": (0, 127, 255),
+}
+
+
+def color_from_name(color_name: str) -> Tuple[int, int, int]:
+    """Return an RGB tuple for a given color name.
+
+    Unrecognised names default to a medium gray to match the C# helper.
+    """
+    if not color_name:
+        return (111, 111, 111)
+    return _COLOR_MAP.get(color_name.lower(), (111, 111, 111))
+
+
+_VALID_COLOR_NAMES: List[str] = [
+    "Red",
+    "Orange",
+    "Yellow",
+    "Chartreuse",
+    "Green",
+    "Spring Green",
+    "Cyan",
+    "Azure",
+    "Blue",
+    "Magenta",
+    "Rose",
+    "Black",
+    "White",
+    "Silver",
+    "Gray",
+    "Maroon",
+    "Olive",
+    "Purple",
+]
+
+
+def is_valid_color_name(color_name: str) -> bool:
+    return color_name in _VALID_COLOR_NAMES
+
+
+def get_color_name_from_hsl(hsl: HSLColor) -> str:
+    """Return the nearest human-friendly color name for ``hsl``.
+
+    This mirrors ``Utils.GetColorNameFromHSL`` in the C# code.
+    """
+    if hsl.luminance < 0.10:
+        return "Black"
+    if hsl.luminance > 0.9:
+        return "White"
+    if hsl.saturation < 0.12:
+        return "Gray"
+    h = hsl.hue
+    if h < 15 or h >= 345:
+        return "Red"
+    if 15 <= h < 45:
+        return "Orange"
+    if 45 <= h < 75:
+        return "Yellow"
+    if 75 <= h < 105:
+        return "Chartreuse"
+    if 105 <= h < 135:
+        return "Green" if hsl.luminance < 0.40 else "Lime"
+    if 135 <= h < 165:
+        return "Spring Green"
+    if 165 <= h < 195:
+        return "Cyan"
+    if 195 <= h < 225:
+        return "Azure"
+    if 225 <= h < 255:
+        return "Blue"
+    if 255 <= h < 315:
+        return "Purple" if hsl.luminance < 0.40 else "Magenta"
+    if 315 <= h < 345:
+        return "Rose"
+    return "Gray"

--- a/python-port/modules/__init__.py
+++ b/python-port/modules/__init__.py
@@ -1,0 +1,6 @@
+"""Module framework for BrainSimIII Python port."""
+from .module_base import ModuleBase
+from .module_description import ModuleDescription
+from .module_handler import ModuleHandler
+
+__all__ = ["ModuleBase", "ModuleDescription", "ModuleHandler"]

--- a/python-port/modules/module_add_counts.py
+++ b/python-port/modules/module_add_counts.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Module that adds count-based relationships in the UKS.
+
+This is a port of the C# ``ModuleAddCounts``.  It scans all Things in the
+knowledge store and, for each relationship type, adds an aggregate relationship
+indicating how many times targets sharing a common ancestor occur.  The count is
+encoded into the relationship type label, mirroring the behaviour of the
+original module which stored the count as a relationship type property.
+"""
+
+import threading
+from typing import Dict, List, Tuple
+
+from .module_base import ModuleBase
+from uks import UKS, Thing, Relationship
+
+
+class ModuleAddCounts(ModuleBase):
+    """Periodically add count relationships to Things."""
+
+    def __init__(self) -> None:
+        super().__init__(label="ModuleAddCounts")
+        self.is_enabled: bool = False
+        self.debug_string = "Initialized\n"
+        self._timer: threading.Timer | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        self._setup()
+
+    def fire(self) -> None:
+        if not self.initialized:
+            self.initialize()
+            self.initialized = True
+
+    # ------------------------------------------------------------------
+    def _setup(self) -> None:
+        if self._timer is None:
+            self._timer = threading.Timer(10.0, self._same_thread_callback)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _same_thread_callback(self) -> None:
+        if not self.is_enabled:
+            self._setup()
+            return
+        threading.Thread(target=self.do_the_work, daemon=True).start()
+        self._setup()
+
+    # ------------------------------------------------------------------
+    def do_the_work(self) -> None:
+        if self.the_uks is None:
+            return
+        self.debug_string = "Agent Started\n"
+        for t in list(self.the_uks.UKSList):
+            self._add_count_relationships(t)
+        self.debug_string += "Agent Finished\n"
+
+    # ------------------------------------------------------------------
+    def _add_count_relationships(self, t: Thing) -> None:
+        has_child = self.the_uks.labeled("has-child") if self.the_uks else None
+        for r in list(t.relationships):
+            if has_child is not None and r.reltype is has_child:
+                continue
+            use_rel_type = self._get_instance_type(r.reltype)
+            targets = [
+                rel.target
+                for rel in t.relationships
+                if rel.target is not None and self._get_instance_type(rel.reltype) is use_rel_type
+            ]
+            best_matches = self._get_attribute_counts(targets)
+            for match, count in best_matches:
+                rel_label = f"{use_rel_type.Label}.{count}"
+                existing = self.the_uks.get_relationship(t, rel_label, match)
+                if existing is None:
+                    self.the_uks.add_statement(t, rel_label, match)
+                    self.debug_string += f"Added: {t.Label} {rel_label} {match.Label}\n"
+
+    # ------------------------------------------------------------------
+    def _get_attribute_counts(self, ts: List[Thing]) -> List[Tuple[Thing, int]]:
+        ret: List[Tuple[Thing, int]] = []
+        if not ts:
+            return ret
+        counts: Dict[Thing, int] = {}
+        for t in ts:
+            for anc in t.AncestorList():
+                counts[anc] = counts.get(anc, 0) + 1
+        unknown = self.the_uks.labeled("unknownObject") if self.the_uks else None
+        for k, v in counts.items():
+            if unknown and unknown in k.AncestorList() and k is not unknown and v > 1:
+                ret.append((k, v))
+        return ret
+
+    def _get_instance_type(self, t: Thing) -> Thing:
+        use = t
+        while (
+            use.Parents
+            and use.Label[-1:].isdigit()
+            and "." not in t.Label
+            and use.Label.startswith(use.Parents[0].Label)
+        ):
+            use = use.Parents[0]
+        return use
+
+    # Utility for tests to cancel timer
+    def cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None

--- a/python-port/modules/module_attribute_bubble.py
+++ b/python-port/modules/module_attribute_bubble.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+"""Port of the C# ``ModuleAttributeBubble``.
+
+The module examines all Things in the UKS and bubbles up child relationships to
+parent Things when enough children share the same relationship.  Conflicting
+relationships and weighted counts are taken into account to emulate the
+behaviour of the original module.
+"""
+
+import threading
+from dataclasses import dataclass, field
+from typing import List
+
+from .module_base import ModuleBase
+from uks import Thing, Relationship
+
+
+@dataclass
+class RelDest:
+    rel_type: Thing
+    target: Thing
+    relationships: List[Relationship] = field(default_factory=list)
+
+
+class ModuleAttributeBubble(ModuleBase):
+    """Periodically bubble child attributes to their parent."""
+
+    def __init__(self) -> None:
+        super().__init__(label="ModuleAttributeBubble")
+        self.is_enabled: bool = False
+        self.debug_string = "Initialized\n"
+        self._timer: threading.Timer | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        self._setup()
+
+    def fire(self) -> None:
+        if not self.initialized:
+            self.initialize()
+            self.initialized = True
+
+    def _setup(self) -> None:
+        if self._timer is None:
+            self._timer = threading.Timer(10.0, self._same_thread_callback)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _same_thread_callback(self) -> None:
+        if not self.is_enabled:
+            self._setup()
+            return
+        threading.Thread(target=self.do_the_work, daemon=True).start()
+        self._setup()
+
+    def cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    # ------------------------------------------------------------------
+    def do_the_work(self) -> None:
+        if self.the_uks is None:
+            return
+        self.debug_string = "Bubbler Started\n"
+        for t in list(self.the_uks.UKSList):
+            if t.has_ancestor("Object"):
+                self._bubble_child_attributes(t)
+        self.debug_string += "Bubbler Finished\n"
+
+    # ------------------------------------------------------------------
+    def _bubble_child_attributes(self, t: Thing) -> None:
+        if not t.Children or t.Label == "unknownObject":
+            return
+        item_counts: List[RelDest] = []
+        has_child = self.the_uks.labeled("has-child") if self.the_uks else None
+        for child in t.ChildrenWithSubclasses:
+            for r in child.relationships:
+                if has_child and r.reltype is has_child:
+                    continue
+                use_rel_type = self._get_instance_type(r.reltype)
+                found = next(
+                    (x for x in item_counts if x.rel_type is use_rel_type and x.target is r.target),
+                    None,
+                )
+                if not found:
+                    found = RelDest(use_rel_type, r.target)
+                    item_counts.append(found)
+                found.relationships.append(r)
+        if not item_counts:
+            return
+        sorted_items = sorted(item_counts, key=lambda x: len(x.relationships), reverse=True)
+        exclude = {"hasProperty", "isTransitive", "isCommutative", "inverseOf", "hasAttribute", "hasDigit"}
+        for rr in sorted_items:
+            if rr.rel_type.Label in exclude:
+                continue
+            r = self.the_uks.get_relationship(t, rr.rel_type, rr.target)
+            current_weight = r.weight if r else 0.0
+            total_count = len(t.Children)
+            positive_rels = [rel for rel in rr.relationships if rel.weight > 0.5]
+            positive_count = len(positive_rels)
+            positive_weight = sum(rel.weight for rel in rr.relationships)
+            negative_count = 0
+            negative_weight = 0
+            for other in sorted_items:
+                if other is rr:
+                    continue
+                if self._relationships_conflict(rr, other):
+                    negative_count += len(other.relationships)
+                    negative_weight += sum(rel.weight for rel in other.relationships)
+            no_info_count = total_count - (positive_count + negative_count)
+            positive_weight += current_weight + no_info_count * 0.51
+            if no_info_count < 0:
+                no_info_count = 0
+            if negative_count >= positive_count:
+                if r:
+                    t.remove_relationship(r)
+                    self.debug_string += f"Removed {r} \n"
+                continue
+            delta_weight = positive_weight - negative_weight
+            if delta_weight < 0.8:
+                target_weight = -0.1
+            elif delta_weight < 1.7:
+                target_weight = 0.01
+            elif delta_weight < 2.7:
+                target_weight = 0.2
+            else:
+                target_weight = 0.3
+            if current_weight == 0:
+                current_weight = 0.5
+            new_weight = current_weight + target_weight
+            if new_weight > 0.99:
+                new_weight = 0.99
+            if new_weight != current_weight or r is None:
+                if new_weight < 0.5:
+                    if r:
+                        t.remove_relationship(r)
+                        self.debug_string += f"Removed {r} \n"
+                else:
+                    if r is None:
+                        r = t.add_relationship(rr.rel_type, rr.target)
+                    r.weight = new_weight
+                    for existing in list(t.relationships):
+                        if existing is r:
+                            continue
+                        tmp = RelDest(existing.reltype, existing.target, [existing])
+                        if self._relationships_conflict(tmp, rr):
+                            t.remove_relationship(existing)
+                    self.debug_string += f"{r}   {r.weight:.0f}\n"
+
+    # ------------------------------------------------------------------
+    def _relationships_conflict(self, r1: RelDest, r2: RelDest) -> bool:
+        if r1.rel_type is r2.rel_type and r1.target is r2.target:
+            return False
+        is_exclusive = self.the_uks.labeled("isExclusive") if self.the_uks else None
+        allow_multiple = self.the_uks.labeled("allowMultiple") if self.the_uks else None
+        if r1.rel_type is r2.rel_type:
+            parents = self._find_common_parents(r1.target, r2.target)
+            for parent in parents:
+                if (
+                    is_exclusive
+                    and parent.has_property(is_exclusive)
+                    or (allow_multiple and parent.has_property(allow_multiple))
+                ):
+                    return True
+        if r1.target is r2.target:
+            parents = self._find_common_parents(r1.target, r2.target)
+            for parent in parents:
+                if is_exclusive and parent.has_property(is_exclusive):
+                    return True
+            r1_attrs = r1.rel_type.get_attributes()
+            r2_attrs = r2.rel_type.get_attributes()
+            r1_not = next((x for x in r1_attrs if x.Label in {"not", "no"}), None)
+            r2_not = next((x for x in r2_attrs if x.Label in {"not", "no"}), None)
+            if (r1_not is None) != (r2_not is None):
+                return True
+            for a1 in r1_attrs:
+                for a2 in r2_attrs:
+                    if a1 is a2:
+                        continue
+                    for p in self._find_common_parents(a1, a2):
+                        if (
+                            is_exclusive
+                            and p.has_property(is_exclusive)
+                            or (allow_multiple and p.has_property(allow_multiple))
+                        ):
+                            return True
+            has_number1 = any(x.has_ancestor_labeled("number") for x in r1_attrs)
+            has_number2 = any(x.has_ancestor_labeled("number") for x in r2_attrs)
+            if has_number1 or has_number2:
+                return True
+        return False
+
+    def _find_common_parents(self, t: Thing, t1: Thing) -> List[Thing]:
+        return [p for p in t.Parents if p in t1.Parents]
+
+    def _get_instance_type(self, t: Thing) -> Thing:
+        use = t
+        while (
+            use.Parents
+            and use.Label[-1:].isdigit()
+            and "." not in t.Label
+            and use.Label.startswith(use.Parents[0].Label)
+        ):
+            use = use.Parents[0]
+        return use

--- a/python-port/modules/module_balance_tree.py
+++ b/python-port/modules/module_balance_tree.py
@@ -1,0 +1,79 @@
+"""Port of the C# ModuleBalanceTree module.
+
+This module ensures that Things in the UKS do not end up with an excessive
+number of direct children.  When a Thing exceeds ``max_children`` a new parent
+Thing is created (sharing the original label with an auto-incremented suffix)
+so that the children are distributed more evenly between the old and new
+parents.  The original implementation uses a timer to periodically scan the
+knowledge base; that behaviour is reproduced using ``threading.Timer``.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from .module_base import ModuleBase
+from uks import UKS, Thing
+
+
+class ModuleBalanceTree(ModuleBase):
+    def __init__(self, label: Optional[str] = None) -> None:
+        super().__init__(label)
+        self.max_children: int = 6
+        self._timer: Optional[threading.Timer] = None
+        self.debug_string = "Initialized\n"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        self._setup_timer()
+
+    def fire(self) -> None:  # timer driven
+        if not self.initialized:
+            self.initialize()
+
+    def _setup_timer(self) -> None:
+        if self._timer is None:
+            self._timer = threading.Timer(10.0, self._callback)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _callback(self) -> None:
+        if self.is_enabled and self.the_uks is not None:
+            threading.Thread(target=self.do_the_work, daemon=True).start()
+        # Reschedule
+        self._timer = None
+        self._setup_timer()
+
+    # ------------------------------------------------------------------
+    # Core behaviour
+    # ------------------------------------------------------------------
+    def do_the_work(self) -> None:
+        if self.the_uks is None:
+            return
+        self.debug_string = "Agent Started\n"
+        for t in list(self.the_uks.UKSList):
+            if t.has_ancestor("Object") and "." not in t.Label:
+                self.handle_excessive_children(t)
+        self.debug_string += "Agent Finished\n"
+
+    def handle_excessive_children(self, t: Thing) -> None:
+        if self.the_uks is None:
+            return
+        while len(t.Children) > self.max_children:
+            new_parent = self.the_uks.add_thing(t.Label, t)
+            self.debug_string += f"Created new class: {new_parent.Label}\n"
+            while len(new_parent.Children) < self.max_children and t.Children:
+                child = t.Children[0]
+                child.remove_parent(t)
+                child.add_parent(new_parent)
+
+    # ------------------------------------------------------------------
+    # Parameters
+    # ------------------------------------------------------------------
+    def get_parameters(self) -> dict:
+        return {"max_children": self.max_children}
+
+    def set_parameters(self, params: dict) -> None:
+        self.max_children = int(params.get("max_children", self.max_children))

--- a/python-port/modules/module_base.py
+++ b/python-port/modules/module_base.py
@@ -1,0 +1,70 @@
+"""Base class for BrainSimIII modules.
+
+This module mirrors the responsibilities of the original C# ``ModuleBase``
+type, providing lifecycle hooks such as ``initialize``, ``fire`` and
+``reset``.  Modules derive from this class and gain a ``label`` plus access to
+the shared :class:`~uks.UKS` instance used for knowledge storage.  Additional
+hooks ``pre_step`` and ``post_step`` are invoked around each ``fire`` call to
+allow fine‑grained control over execution.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from uks import UKS
+
+
+class ModuleBase:
+    """Abstract base class for all modules with lifecycle hooks."""
+
+    def __init__(self, label: Optional[str] = None) -> None:
+        self.label = label or self.__class__.__name__
+        self.is_enabled: bool = True
+        self.initialized: bool = False
+        self.the_uks: Optional[UKS] = None
+
+    # -- lifecycle -----------------------------------------------------
+    def initialize(self) -> None:  # pragma: no cover - to be overridden
+        """Perform one-time module setup."""
+        raise NotImplementedError
+
+    def reset(self) -> None:
+        """Reset module state for a fresh run."""
+        self.initialized = False
+
+    def pre_step(self) -> None:
+        """Hook executed before each :meth:`fire` call."""
+
+    def fire(self) -> None:  # pragma: no cover - to be overridden
+        """Execute the module's behaviour for one simulation step."""
+        raise NotImplementedError
+
+    def post_step(self) -> None:
+        """Hook executed after each :meth:`fire` call."""
+
+    # -- parameter serialisation --------------------------------------
+    def get_parameters(self) -> Dict[str, Any]:
+        """Return serialisable module parameters."""
+        return {}
+
+    def set_parameters(self, params: Dict[str, Any]) -> None:
+        """Restore parameters previously produced by :meth:`get_parameters`."""
+
+    def serialize(self) -> Dict[str, Any]:
+        return {"class": self.__class__.__name__, "label": self.label, "params": self.get_parameters()}
+
+    @classmethod
+    def deserialize(cls, data: Dict[str, Any]) -> "ModuleBase":
+        obj = cls(label=data.get("label"))
+        obj.set_parameters(data.get("params", {}))
+        return obj
+
+    # -- helpers -------------------------------------------------------
+    def _ensure_initialized(self) -> None:
+        if not self.initialized:
+            self.initialize()
+            self.initialized = True
+
+    def set_uks(self, uks: UKS) -> None:
+        """Assign the shared :class:`UKS` instance."""
+        self.the_uks = uks

--- a/python-port/modules/module_class_create.py
+++ b/python-port/modules/module_class_create.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Port of the C# ModuleClassCreate.
+
+This module examines Things within the UKS and looks for children of a given
+Thing that share common attributes.  If a sufficient number of children share
+an attribute, a new intermediate class is created to group them.
+"""
+
+import threading
+from dataclasses import dataclass
+from typing import List, Dict
+
+from .module_base import ModuleBase
+from uks import UKS, Thing, Relationship
+
+
+@dataclass
+class _RelDest:
+    rel_type: Thing
+    target: Thing
+    relationships: List[Relationship]
+
+
+class ModuleClassCreate(ModuleBase):
+    """Periodically create subclasses based on shared attributes."""
+
+    def __init__(self) -> None:
+        super().__init__(label="ModuleClassCreate")
+        self.is_enabled: bool = False
+        self.debug_string = "Initialized\n"
+        self.max_children = 12
+        self.min_common_attributes = 3
+        self._timer: threading.Timer | None = None
+
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        self._setup()
+
+    def fire(self) -> None:
+        # This module performs its work on a timer; fire ensures initialization
+        if not self.initialized:
+            self.initialize()
+            self.initialized = True
+
+    def reset(self) -> None:  # cancel timer on reset
+        super().reset()
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    # ------------------------------------------------------------------
+    def _setup(self) -> None:
+        if self._timer is None:
+            self._timer = threading.Timer(10.0, self._same_thread_callback)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _same_thread_callback(self) -> None:
+        if not self.is_enabled:
+            self._setup()
+            return
+        threading.Thread(target=self.do_the_work, daemon=True).start()
+        self._setup()
+
+    # ------------------------------------------------------------------
+    def do_the_work(self) -> None:
+        if self.the_uks is None:
+            return
+        self.debug_string = "Agent Started\n"
+        for t in list(self.the_uks.UKSList):
+            if (
+                t.Label.find(".") == -1
+                and "unknown" not in t.Label
+                and any(p.Label == "Object" for p in t.AncestorList())
+            ):
+                self._handle_class_with_common_attributes(t)
+        self.debug_string += "Agent  Finished\n"
+
+    def _handle_class_with_common_attributes(self, t: Thing) -> None:
+        attributes: List[_RelDest] = []
+        for child in t.Children:
+            for r in child.relationships:
+                if r.reltype.Label == "has-child":
+                    continue
+                key = next(
+                    (a for a in attributes if a.rel_type is r.reltype and a.target is r.target),
+                    None,
+                )
+                if key is None:
+                    key = _RelDest(r.reltype, r.target, [])
+                    attributes.append(key)
+                key.relationships.append(r)
+        for item in attributes:
+            if len(item.relationships) >= self.min_common_attributes:
+                new_label = f"{t.Label}.{item.rel_type.Label}.{item.target.Label}"
+                new_parent = self.the_uks.get_or_add_thing(new_label, t)
+                new_parent.add_relationship(item.rel_type, item.target)
+                self.debug_string += f"Created new subclass {new_parent.Label}\n"
+                for rel in item.relationships:
+                    child = rel.source
+                    child.add_parent(new_parent)
+                    for pr in list(t.relationships):
+                        if pr.reltype.Label == "has-child" and pr.target is child:
+                            t.remove_relationship(pr)
+
+    # Utility for tests to cancel timer
+    def cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None

--- a/python-port/modules/module_description.py
+++ b/python-port/modules/module_description.py
@@ -1,0 +1,12 @@
+"""Module description container."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ModuleDescription:
+    """Holds metadata about a module."""
+
+    name: str
+    description: str = ""

--- a/python-port/modules/module_gpt_info.py
+++ b/python-port/modules/module_gpt_info.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Port of the C# ModuleGPTInfo module.
+
+The original module uses OpenAI's GPT models to verify relationships and to
+fetch commonsense information.  The Python port provides similar helpers using
+the OpenAI HTTP API.  Calls require the ``OPENAI_API_KEY`` environment variable
+and will raise :class:`RuntimeError` if it is missing.
+"""
+
+import os
+import json
+from typing import Optional
+
+from .module_base import ModuleBase
+
+
+class ModuleGPTInfo(ModuleBase):
+    Output: str = ""
+
+    def initialize(self) -> None:
+        # Validate that an API key is available up-front so calls fail fast
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        # No heavy initialisation is required beyond environment validation,
+        # but the flag indicates the module is ready for use
+
+    def fire(self) -> None:
+        self._ensure_initialized()
+        # this module is request driven; nothing to do each step
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _call_openai(prompt: str, system: Optional[str] = None) -> str:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        import requests  # local import to avoid dependency when unused
+
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        payload = {
+            "model": "gpt-3.5-turbo",
+            "messages": []
+        }
+        if system:
+            payload["messages"].append({"role": "system", "content": system})
+        payload["messages"].append({"role": "user", "content": prompt})
+        resp = requests.post("https://api.openai.com/v1/chat/completions", headers=headers, data=json.dumps(payload), timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+
+    @staticmethod
+    def get_chatgpt_verify_parent_child(child: str, parent: str) -> str:
+        system = "Provide commonsense facts about the following:"  # brief system prompt
+        prompt = f"Is the following true: a(n) {child} is a(n) {parent}? (yes or no, no explanation)"
+        return ModuleGPTInfo._call_openai(prompt, system)
+
+    @staticmethod
+    def get_chatgpt_parents(text: str) -> str:
+        text = text.lstrip('.')
+        user = f"Provide commonsense classification answer the request which is appropriate for a 5 year old: What is-a {text}"
+        system = (
+            "This is a classification request. Examples: horse is-a | animal, mammal\n"
+            "chimpanzee is-a | primate, mammal. Answer is formatted: is-a | VALUE, VALUE, VALUE"
+        )
+        return ModuleGPTInfo._call_openai(user, system)
+
+    @staticmethod
+    def get_chatgpt_data(text: str) -> str:
+        text = text.replace('.', '')
+        user = f"Provide commonsense facts to answer the request: what is a {text}"
+        system = (
+            "Provide answers that are common sense to a 10 year old. Each Answer in the format VALUE-NAME | VALUE, VALUE"
+        )
+        return ModuleGPTInfo._call_openai(user, system)

--- a/python-port/modules/module_handler.py
+++ b/python-port/modules/module_handler.py
@@ -1,0 +1,91 @@
+"""Module loading and execution support."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Type, Any
+import importlib
+import inspect
+import pkgutil
+
+from .module_base import ModuleBase
+from .module_description import ModuleDescription
+from uks import UKS
+
+
+@dataclass
+class RegisteredModule:
+    name: str
+    cls: Type[ModuleBase]
+    description: ModuleDescription
+
+
+class ModuleHandler:
+    """Manage active modules and dispatch their ``fire`` methods."""
+
+    def __init__(self) -> None:
+        self.registry: Dict[str, RegisteredModule] = {}
+        self.active_modules: List[ModuleBase] = []
+        self.the_uks = UKS()
+        self.discover()
+
+    # -- registration --------------------------------------------------
+    def register(self, cls: Type[ModuleBase], description: str = "") -> None:
+        desc = ModuleDescription(name=cls.__name__, description=description)
+        self.registry[cls.__name__] = RegisteredModule(cls.__name__, cls, desc)
+        self.the_uks.get_or_add_thing(cls.__name__)
+
+    def discover(self, package: str = __package__ or "modules") -> None:
+        """Dynamically discover and register modules in *package*."""
+        try:
+            pkg = importlib.import_module(package)
+        except Exception:  # pragma: no cover - invalid package
+            return
+        for _, modname, _ in pkgutil.iter_modules(pkg.__path__):
+            module = importlib.import_module(f"{package}.{modname}")
+            for _, obj in inspect.getmembers(module, inspect.isclass):
+                if issubclass(obj, ModuleBase) and obj is not ModuleBase:
+                    self.register(obj)
+
+    # -- activation ----------------------------------------------------
+    def activate(self, name: str) -> ModuleBase:
+        reg = self.registry.get(name)
+        if reg is None:
+            raise KeyError(f"Unknown module: {name}")
+        module = reg.cls()
+        module.set_uks(self.the_uks)
+        module._ensure_initialized()
+        self.active_modules.append(module)
+        return module
+
+    def deactivate(self, label: str) -> None:
+        self.active_modules = [m for m in self.active_modules if m.label != label]
+
+    # -- execution -----------------------------------------------------
+    def fire_modules(self) -> None:
+        for module in list(self.active_modules):
+            if module.is_enabled:
+                module.pre_step()
+                module.fire()
+                module.post_step()
+
+    # -- lifecycle utilities -----------------------------------------
+    def reset_all(self) -> None:
+        for module in self.active_modules:
+            module.reset()
+
+    # -- parameter serialisation -------------------------------------
+    def serialize_active(self) -> List[Dict[str, Any]]:
+        return [m.serialize() for m in self.active_modules]
+
+    def load_active(self, data: List[Dict[str, Any]]) -> None:
+        self.active_modules = []
+        for mdata in data:
+            name = mdata.get("class")
+            reg = self.registry.get(name)
+            if not reg:
+                continue
+            module = reg.cls(label=mdata.get("label"))
+            module.set_uks(self.the_uks)
+            module._ensure_initialized()
+            module.set_parameters(mdata.get("params", {}))
+            self.active_modules.append(module)

--- a/python-port/modules/module_remove_redundancy.py
+++ b/python-port/modules/module_remove_redundancy.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Module that removes redundant attributes in the UKS.
+
+This is a direct port of the C# ``ModuleRemoveRedundancy``.  The module runs
+periodically and weakens or deletes relationships on Things when the same
+relationship exists on a parent with sufficient confidence.  It helps maintain a
+compact knowledge store by avoiding duplicate information on child nodes.
+"""
+
+import threading
+
+from .module_base import ModuleBase
+from uks import UKS, Thing, Relationship
+
+
+class ModuleRemoveRedundancy(ModuleBase):
+    """Periodically prune redundant attributes from Things."""
+
+    def __init__(self) -> None:
+        super().__init__(label="ModuleRemoveRedundancy")
+        self.is_enabled: bool = False
+        self.debug_string = "Initialized\n"
+        self._timer: threading.Timer | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        self._setup()
+
+    def fire(self) -> None:
+        # The original module performs all work on a timer; ``fire`` merely
+        # ensures initialization and updates the dialog (not implemented here).
+        if not self.initialized:
+            self.initialize()
+            self.initialized = True
+
+    # ------------------------------------------------------------------
+    def _setup(self) -> None:
+        if self._timer is None:
+            self._timer = threading.Timer(10.0, self._same_thread_callback)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _same_thread_callback(self) -> None:
+        if not self.is_enabled:
+            # Reschedule the timer and exit
+            self._setup()
+            return
+        threading.Thread(target=self.do_the_work, daemon=True).start()
+        self._setup()
+
+    # ------------------------------------------------------------------
+    def do_the_work(self) -> None:
+        if self.the_uks is None:
+            return
+        self.debug_string = "Agent Started\n"
+        for t in list(self.the_uks.UKSList):
+            self._remove_redundant_attributes(t)
+        self.debug_string += "Agent  Finished\n"
+
+    # ------------------------------------------------------------------
+    def _remove_redundant_attributes(self, t: Thing) -> None:
+        for parent in t.Parents:
+            rels_with_inheritance = self.the_uks.get_all_relationships([parent], False)
+            for i in range(len(t.relationships)):
+                r = t.relationships[i]
+                match = next(
+                    (
+                        x
+                        for x in rels_with_inheritance
+                        if x.source is not r.source
+                        and x.reltype is r.reltype
+                        and x.target is r.target
+                    ),
+                    None,
+                )
+                if match and match.weight > 0.8:
+                    r.weight -= 0.1
+                    if r.weight < 0.5:
+                        t.remove_relationship(r)
+                        self.debug_string += f"Removed: {r}\n"
+                        return  # relationship list changed; restart on next parent
+                    self.debug_string += f"{r}   ({r.weight:0.00})\n"
+
+    # Utility for tests to cancel timer
+    def cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None

--- a/python-port/modules/module_stress_test.py
+++ b/python-port/modules/module_stress_test.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Stress-testing module for bulk UKS insertion.
+
+This is a direct port of the C# ``ModuleStressTest``.  It exposes a helper
+:func:`add_many_test_items` which creates a large hierarchy of Things within the
+UKS knowledge store.  The method mirrors the original logic and validates the
+requested count, stopping once the desired number of items have been inserted.
+"""
+
+from typing import Optional
+
+from .module_base import ModuleBase
+from uks import UKS
+
+
+class ModuleStressTest(ModuleBase):
+    """Module providing utility methods for stress testing the UKS."""
+
+    Output: str = ""
+
+    def __init__(self) -> None:
+        super().__init__(label="ModuleStressTest")
+
+    def initialize(self) -> None:  # pragma: no cover - no setup required
+        pass
+
+    def fire(self) -> None:  # pragma: no cover - module has no periodic work
+        self._ensure_initialized()
+
+    # ------------------------------------------------------------------
+    def add_many_test_items(self, count: int) -> str:
+        """Populate the UKS with a large number of test items.
+
+        Parameters
+        ----------
+        count:
+            Number of items to insert.  The function returns a descriptive
+            message in case ``count`` is outside the allowed range or upon
+            successful completion.
+        """
+        max_count = 100_000
+        if count <= 0:
+            return "Count less or equal to 0, cannot commence."
+        if count > max_count:
+            return f"Count greater than maxCount {max_count}, cannot commence."
+        if self.the_uks is None:
+            return "UKS not assigned."
+
+        created = 0
+        outer = 0
+        while created < count and outer < 100:
+            parent = self.the_uks.get_or_add_thing(f"A{outer}")
+            created += 1
+            if created >= count:
+                break
+            for j in range(100):
+                parent0 = self.the_uks.get_or_add_thing(f"B{outer}{j}", parent)
+                created += 1
+                if created >= count:
+                    break
+                for k in range(10):
+                    self.the_uks.get_or_add_thing(f"C{outer}{j}{k}", parent0)
+                    created += 1
+                    if created >= count:
+                        break
+                if created >= count:
+                    break
+            outer += 1
+        return "Items added successfully."

--- a/python-port/network.py
+++ b/python-port/network.py
@@ -1,0 +1,397 @@
+"""Network utilities and core simulation engine for the BrainSimIII port.
+
+This module originally started life as a tiny wrapper around a few pieces of
+the C# :file:`Network.cs` file which handled UDP communication.  The real
+project, however, also defines a *neural network* consisting of neurons and
+weighted synapses with a cyclic update loop.  To move the Python port closer
+to feature parity we now provide a small, self‑contained implementation of
+those data structures alongside the existing UDP helpers.
+
+Over time this module has grown to mirror more of the original C# feature set:
+
+* A layer based architecture allowing feed‑forward networks where neurons in
+  lower layers update before those in higher layers.
+* Built‑in activation functions and support for several neuron "types".
+* An optional asynchronous update loop with timing control driven by a worker
+  thread.  The loop can be started and stopped at runtime.
+* A very small Hebbian style learning rule which adjusts synapse weights based
+  on the activity of connected neurons.
+
+The networking helpers remain intentionally lightweight and are sufficient for
+unit tests and local communication.  The neural network implementation is
+designed to be easy to understand while still supporting the essential
+behaviour required by modules built on top of it.
+"""
+from __future__ import annotations
+
+import socket
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+try:  # optional vectorised maths
+    import numpy as np  # type: ignore
+    _HAVE_NUMPY = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAVE_NUMPY = False
+
+UDP_RECEIVE_PORT = 3333
+UDP_SEND_PORT = 3333
+
+
+def _create_udp_socket(broadcast: bool = False) -> socket.socket:
+    """Create a UDP socket optionally configured for broadcast."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    if broadcast:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    return s
+
+
+def broadcast(message: str, port: int = UDP_SEND_PORT, address: Optional[str] = None) -> None:
+    """Send *message* as a UDP broadcast.
+
+    Parameters
+    ----------
+    message:
+        The string message to send.
+    port:
+        The UDP port to broadcast on.  Defaults to :data:`UDP_SEND_PORT`.
+    address:
+        Optional address to broadcast to.  If omitted, ``'<broadcast>'`` is used
+        which lets the OS determine the correct broadcast address.
+    """
+    data = message.encode("utf-8")
+    addr = address or "<broadcast>"
+    with _create_udp_socket(broadcast=True) as s:
+        s.sendto(data, (addr, port))
+
+
+def udp_send(message: str, ip: str, port: int) -> None:
+    """Send *message* to ``ip``/``port`` via UDP."""
+    data = message.encode("utf-8")
+    with _create_udp_socket() as s:
+        s.sendto(data, (ip, port))
+
+
+# ---------------------------------------------------------------------------
+# Neural network simulation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Synapse:
+    """Connection between two neurons with an associated ``weight``.
+
+    Parameters
+    ----------
+    pre, post:
+        Identifiers of the pre‑ and post‑synaptic neurons.
+    weight:
+        Synaptic strength used when propagating signals.
+    learning_rate:
+        If non‑zero the synapse weight is adjusted after each update using a
+        basic Hebbian rule ``w += lr * pre_value * post_value``.
+    stdp_rate/stdp_tau:
+        Parameters for a very small spike‑timing dependent plasticity rule.
+        When both neurons have recently fired within ``stdp_tau`` seconds the
+        weight is adjusted by ``± stdp_rate * exp(-|Δt|/stdp_tau)`` depending on
+        the order of firing.
+    """
+
+    pre: str
+    post: str
+    weight: float = 1.0
+    learning_rate: float = 0.0
+    stdp_rate: float = 0.0
+    stdp_tau: float = 1.0
+
+
+def _identity(x: float) -> float:
+    return x
+
+
+def _relu(x: float) -> float:
+    return x if x > 0 else 0.0
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+_ACTIVATIONS: Dict[str, Callable[[float], float]] = {
+    "linear": _identity,
+    "relu": _relu,
+    "sigmoid": _sigmoid,
+}
+
+
+@dataclass(slots=True)
+class Neuron:
+    """A neuron used by :class:`Network`.
+
+    Parameters
+    ----------
+    id:
+        Identifier for the neuron.  Used when creating connections.
+    bias:
+        Constant value added to the neuron's input each update.
+    activation:
+        Activation function name or callable.  ``'linear'`` (identity) is used
+        by default.
+    layer:
+        Execution layer used when performing a feed‑forward step.  Neurons in a
+        lower layer are updated before those in higher layers.  When all
+        neurons have ``layer=0`` the behaviour is the same as a classic
+        synchronous update.
+    kind:
+        Either ``'excitatory'`` or ``'inhibitory'``.  Inhibitory neurons invert
+        the sign of their outgoing signals.
+    spike_threshold:
+        Value above which the neuron is considered to have "fired".  The most
+        recent firing time is stored in :attr:`last_spike` for use by the STDP
+        learning rule.
+    """
+
+    id: str
+    value: float = 0.0
+    bias: float = 0.0
+    activation: Callable[[float], float] = _identity
+    layer: int = 0
+    kind: str = "excitatory"  # or "inhibitory" or "spiking"
+    spike_threshold: float = 1.0
+    refractory: float = 0.0
+    last_spike: Optional[float] = None
+
+
+class Network:
+    """A very small neural network engine.
+
+    Neurons are stored by ``id`` and connections are represented by
+    :class:`Synapse` instances.  The :meth:`step` method performs a synchronous
+    update across all neurons so that each cycle uses the output values from
+    the previous cycle, matching the behaviour of the original C# engine.
+    """
+
+    def __init__(self) -> None:
+        self.neurons: Dict[str, Neuron] = {}
+        self._incoming: Dict[str, List[Synapse]] = {}
+        self.layers: Dict[int, List[str]] = {}
+        self._synapses: List[Synapse] = []
+        self._running = False
+        self._paused = False
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.RLock()
+        self.time: float = 0.0
+        self._dt: float = 1.0
+        self.profiler: Optional[Callable[[float], None]] = None
+
+    # -- construction -------------------------------------------------
+    def add_neuron(
+        self,
+        neuron_id: str,
+        *,
+        bias: float = 0.0,
+        activation: Optional[Callable[[float], float]] | str = None,
+        layer: int = 0,
+        kind: str = "excitatory",
+        spike_threshold: float = 1.0,
+        refractory: float = 0.0,
+    ) -> Neuron:
+        """Create a neuron and add it to the network.
+
+        ``activation`` may be either a callable or the name of one of the
+        built‑in activation functions (``'linear'``, ``'relu'`` or
+        ``'sigmoid'``).  ``kind`` specifies whether the neuron is excitatory or
+        inhibitory.
+        """
+
+        if neuron_id in self.neurons:
+            raise ValueError(f"Neuron '{neuron_id}' already exists")
+
+        if isinstance(activation, str):
+            act_fn = _ACTIVATIONS[activation]
+        else:
+            act_fn = activation or _identity
+
+        neuron = Neuron(
+            neuron_id,
+            bias=bias,
+            activation=act_fn,
+            layer=layer,
+            kind=kind,
+            spike_threshold=spike_threshold,
+            refractory=refractory,
+        )
+        self.neurons[neuron_id] = neuron
+        self._incoming[neuron_id] = []
+        self.layers.setdefault(layer, []).append(neuron_id)
+        return neuron
+
+    def connect(
+        self,
+        pre: str,
+        post: str,
+        weight: float = 1.0,
+        *,
+        learning_rate: float = 0.0,
+        stdp_rate: float = 0.0,
+        stdp_tau: float = 1.0,
+    ) -> Synapse:
+        """Create a synapse from ``pre`` to ``post`` with ``weight``.
+
+        ``learning_rate`` enables the simple Hebbian weight update rule.
+        ``stdp_rate`` and ``stdp_tau`` control spike‑timing dependent
+        plasticity.
+        """
+
+        if pre not in self.neurons or post not in self.neurons:
+            raise KeyError("Both neurons must be added before connecting")
+        syn = Synapse(pre, post, weight, learning_rate, stdp_rate, stdp_tau)
+        self._incoming[post].append(syn)
+        self._synapses.append(syn)
+        return syn
+
+    # -- runtime ------------------------------------------------------
+    def set_input(self, neuron_id: str, value: float) -> None:
+        """Directly set the output value of ``neuron_id``."""
+        with self._lock:
+            self.neurons[neuron_id].value = value
+
+    def step(self, dt: float = 1.0) -> None:
+        """Advance the simulation by one cycle.
+
+        The update proceeds layer by layer.  Neurons in a lower ``layer`` are
+        evaluated first and the resulting values immediately committed so that
+        subsequent layers operate on the most recent outputs.  If all neurons
+        reside in the same layer the behaviour degenerates to a synchronous
+        update matching the original simple engine.
+
+        ``dt`` specifies the simulated time delta added to :attr:`time` and is
+        also used by the STDP learning rule.
+        """
+
+        start = time.perf_counter()
+        with self._lock:
+            self.time += dt
+            for layer in sorted(self.layers.keys()):
+                next_values: Dict[str, float] = {}
+                for neuron_id in self.layers[layer]:
+                    neuron = self.neurons[neuron_id]
+                    if not self._incoming[neuron_id]:
+                        next_values[neuron_id] = neuron.value
+                        continue
+
+                    # respect refractory period for spiking neurons
+                    if (
+                        neuron.kind == "spiking"
+                        and neuron.last_spike is not None
+                        and self.time - neuron.last_spike < neuron.refractory
+                    ):
+                        next_values[neuron_id] = 0.0
+                        continue
+
+                    total = neuron.bias
+                    synapses = self._incoming[neuron_id]
+                    if _HAVE_NUMPY and synapses:
+                        pre_vals = np.array(
+                            [
+                                self.neurons[s.pre].value
+                                * (1.0 if self.neurons[s.pre].kind == "excitatory" else -1.0)
+                                for s in synapses
+                            ],
+                            dtype=float,
+                        )
+                        weights = np.array([s.weight for s in synapses], dtype=float)
+                        total += float(np.dot(pre_vals, weights))
+                    else:
+                        for syn in synapses:
+                            sign = 1.0 if self.neurons[syn.pre].kind == "excitatory" else -1.0
+                            total += self.neurons[syn.pre].value * syn.weight * sign
+
+                    value = neuron.activation(total)
+                    if neuron.kind == "spiking":
+                        next_values[neuron_id] = 1.0 if value >= neuron.spike_threshold else 0.0
+                    else:
+                        next_values[neuron_id] = value
+                for neuron_id, value in next_values.items():
+                    neuron = self.neurons[neuron_id]
+                    neuron.value = value
+                    if value >= neuron.spike_threshold:
+                        neuron.last_spike = self.time
+
+            # -- learning ---------------------------------------------
+            for syn in self._synapses:
+                pre_val = self.neurons[syn.pre].value
+                post_val = self.neurons[syn.post].value
+                if syn.learning_rate != 0.0:
+                    syn.weight += syn.learning_rate * pre_val * post_val
+                if syn.stdp_rate != 0.0:
+                    pre_t = self.neurons[syn.pre].last_spike
+                    post_t = self.neurons[syn.post].last_spike
+                    if pre_t is not None and post_t is not None:
+                        dt_spike = post_t - pre_t
+                        if abs(dt_spike) <= syn.stdp_tau:
+                            delta = syn.stdp_rate * math.exp(-abs(dt_spike) / syn.stdp_tau)
+                            if dt_spike > 0:
+                                syn.weight += delta
+                            elif dt_spike < 0:
+                                syn.weight -= delta
+
+        if self.profiler:
+            self.profiler(time.perf_counter() - start)
+
+    # -- asynchronous execution -------------------------------------
+    def run(self, tick_rate: float = 10.0) -> None:
+        """Start an asynchronous update loop.
+
+        Parameters
+        ----------
+        tick_rate:
+            Number of :meth:`step` executions per second.  The inverse is used
+            as ``dt`` for both timing and the simulated :attr:`time`.
+        """
+
+        if self._running:
+            return
+
+        self._dt = 1.0 / tick_rate
+        with self._lock:
+            self._running = True
+            self._paused = False
+
+        def loop() -> None:
+            next_time = time.perf_counter()
+            while self._running:
+                if not self._paused:
+                    self.step(self._dt)
+                    next_time += self._dt
+                sleep = next_time - time.perf_counter()
+                if sleep > 0:
+                    time.sleep(sleep)
+                else:
+                    next_time = time.perf_counter()
+
+        self._thread = threading.Thread(target=loop, daemon=True)
+        self._thread.start()
+
+    def pause(self) -> None:
+        """Temporarily pause the asynchronous update loop."""
+        with self._lock:
+            self._paused = True
+
+    def resume(self) -> None:
+        """Resume a paused asynchronous update loop."""
+        with self._lock:
+            self._paused = False
+
+    def stop(self) -> None:
+        """Stop the asynchronous update loop started by :meth:`run`."""
+
+        with self._lock:
+            self._running = False
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+

--- a/python-port/tests/test_colors.py
+++ b/python-port/tests/test_colors.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import sys
+from pathlib import Path
+
+# Allow importing modules from the python-port directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from colors import (
+    HSLColor,
+    color_from_name,
+    get_color_name_from_hsl,
+    is_valid_color_name,
+)
+
+
+def test_color_from_name_and_validation():
+    assert color_from_name("red") == (255, 0, 0)
+    assert color_from_name("unknown") == (111, 111, 111)
+    assert is_valid_color_name("Red")
+    assert not is_valid_color_name("unknown")
+
+
+def test_hsl_round_trip():
+    rgb = (10, 200, 100)
+    hsl = HSLColor.from_rgb(*rgb)
+    assert hsl.to_rgb() == rgb
+
+
+def test_get_color_name_from_hsl():
+    red = HSLColor.from_rgb(255, 0, 0)
+    assert get_color_name_from_hsl(red) == "Red"
+    white = HSLColor(luminance=0.95)
+    assert get_color_name_from_hsl(white) == "White"

--- a/python-port/tests/test_module_add_counts.py
+++ b/python-port/tests/test_module_add_counts.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+# Add python-port to sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules.module_add_counts import ModuleAddCounts
+from uks import UKS, ThingLabels, transient_relationships
+
+
+def test_module_add_counts_creates_aggregate_relationships():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+
+    thing = uks.get_or_add_thing("thing")
+    reltype = uks.get_or_add_thing("has-attr")
+    unknown = uks.labeled("unknownObject")
+    group = uks.add_thing("group", unknown)
+    target1 = uks.add_thing("target1", group)
+    target2 = uks.add_thing("target2", group)
+
+    thing.add_relationship(reltype, target1)
+    thing.add_relationship(reltype, target2)
+
+    mod = ModuleAddCounts()
+    mod.set_uks(uks)
+    mod.is_enabled = True
+    mod.do_the_work()
+
+    assert uks.get_relationship("thing", "has-attr.2", "group") is not None

--- a/python-port/tests/test_module_attribute_bubble.py
+++ b/python-port/tests/test_module_attribute_bubble.py
@@ -1,0 +1,41 @@
+from modules.module_attribute_bubble import ModuleAttributeBubble
+from uks import UKS, ThingLabels, transient_relationships
+
+
+def test_attribute_bubble_adds_parent_relationship():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    mod = ModuleAttributeBubble()
+    mod.set_uks(uks)
+    parent = uks.get_or_add_thing("Fruit", uks.labeled("Object"))
+    color = uks.get_or_add_thing("color", uks.labeled("Object"))
+    red = uks.get_or_add_thing("red", color)
+    c1 = uks.get_or_add_thing("apple1", parent)
+    c2 = uks.get_or_add_thing("apple2", parent)
+    c1.add_relationship(color, red)
+    c2.add_relationship(color, red)
+    mod.do_the_work()
+    assert uks.get_relationship(parent, color, red) is not None
+
+
+def test_attribute_bubble_conflicting_children():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    mod = ModuleAttributeBubble()
+    mod.set_uks(uks)
+    parent = uks.get_or_add_thing("Fruit", uks.labeled("Object"))
+    color = uks.get_or_add_thing("color", uks.labeled("Object"))
+    red = uks.get_or_add_thing("red", color)
+    blue = uks.get_or_add_thing("blue", color)
+    has_prop = uks.get_or_add_thing("hasProperty", uks.labeled("Object"))
+    exclusive = uks.get_or_add_thing("isExclusive", uks.labeled("Object"))
+    color.add_relationship(has_prop, exclusive)
+    c1 = uks.get_or_add_thing("apple1", parent)
+    c2 = uks.get_or_add_thing("apple2", parent)
+    c1.add_relationship(color, red)
+    c2.add_relationship(color, blue)
+    mod.do_the_work()
+    assert uks.get_relationship(parent, color, red) is None
+    assert uks.get_relationship(parent, color, blue) is None

--- a/python-port/tests/test_module_balance_tree.py
+++ b/python-port/tests/test_module_balance_tree.py
@@ -1,0 +1,20 @@
+from modules.module_balance_tree import ModuleBalanceTree
+from uks import UKS, ThingLabels, transient_relationships
+
+
+def test_balance_tree_splits_children():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    root = uks.get_or_add_thing("root", uks.labeled("Object"))
+    for i in range(5):
+        child = uks.get_or_add_thing(f"c{i}")
+        child.add_parent(root)
+    module = ModuleBalanceTree()
+    module.set_uks(uks)
+    module.max_children = 2
+    module.do_the_work()
+    # root or its descendents should have at most 2 children each
+    nodes = [root] + root.Descendents()
+    assert all(len(n.Children) <= 2 for n in nodes)
+    assert any(t.Label.startswith("root") and t is not root for t in nodes)

--- a/python-port/tests/test_module_class_create.py
+++ b/python-port/tests/test_module_class_create.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules import ModuleHandler
+
+
+def test_module_class_create_creates_subclass():
+    handler = ModuleHandler()
+    module = handler.activate("ModuleClassCreate")
+    module.is_enabled = True
+    module.min_common_attributes = 2
+    uks = handler.the_uks
+    root = uks.labeled("Object")
+    animal = uks.get_or_add_thing("Animal", root)
+    cat = uks.get_or_add_thing("cat", animal)
+    dog = uks.get_or_add_thing("dog", animal)
+    tail = uks.get_or_add_thing("tail")
+    has = uks.get_or_add_thing("has")
+    cat.add_relationship(has, tail)
+    dog.add_relationship(has, tail)
+    module.do_the_work()
+    new_parent = uks.labeled("Animal.has.tail")
+    assert new_parent is not None
+    assert new_parent in cat.Parents and new_parent in dog.Parents
+    assert animal not in cat.Parents
+    module.cancel_timer()

--- a/python-port/tests/test_module_framework.py
+++ b/python-port/tests/test_module_framework.py
@@ -1,0 +1,73 @@
+import sys
+import sys
+from pathlib import Path
+
+# Allow importing modules from the python-port directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules import ModuleBase, ModuleHandler
+from uks import UKS, ThingLabels, transient_relationships
+
+
+class DummyModule(ModuleBase):
+    def initialize(self) -> None:
+        self.counter = 0
+
+    def pre_step(self) -> None:
+        self.counter += 1
+
+    def fire(self) -> None:
+        self.counter += 1
+
+    def post_step(self) -> None:
+        self.counter += 1
+
+    def get_parameters(self) -> dict:
+        return {"counter": self.counter}
+
+    def set_parameters(self, params: dict) -> None:
+        self.counter = params.get("counter", 0)
+
+
+def test_module_handler_activation_and_fire():
+    handler = ModuleHandler()
+    handler.register(DummyModule, "dummy")
+    module = handler.activate("DummyModule")
+    assert module.initialized
+    assert module.counter == 0
+
+    handler.fire_modules()
+    # pre_step + fire + post_step -> +3
+    assert module.counter == 3
+
+    handler.deactivate(module.label)
+    assert handler.active_modules == []
+
+    # Test serialization
+    module = DummyModule()
+    module.set_parameters({"counter": 7})
+    data = module.serialize()
+    restored = DummyModule.deserialize(data)
+    assert restored.counter == 7
+
+    # ModuleHandler serialization/deserialization
+    handler.register(DummyModule, "dummy")
+    m = handler.activate("DummyModule")
+    m.counter = 2
+    dumped = handler.serialize_active()
+    handler.active_modules = []
+    handler.load_active(dumped)
+    assert handler.active_modules[0].counter == 2
+
+    # Dynamic discovery should have picked up built-in modules
+    assert "ModuleAddCounts" in handler.registry
+
+
+def test_uks_relationships():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    uks.add_relationship("A", "parent", "B")
+    a = uks.labeled("A")
+    assert a.relationships[0].reltype.Label == "parent"
+    assert a.relationships[0].target.Label == "B"

--- a/python-port/tests/test_module_remove_redundancy.py
+++ b/python-port/tests/test_module_remove_redundancy.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+# Add python-port to sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules.module_remove_redundancy import ModuleRemoveRedundancy
+from uks import UKS, ThingLabels, transient_relationships
+
+
+def test_module_remove_redundancy_prunes_child_attributes():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    parent = uks.get_or_add_thing("parent")
+    child = uks.get_or_add_thing("child")
+    child.add_parent(parent)
+    reltype = uks.get_or_add_thing("has-color")
+    color = uks.get_or_add_thing("red")
+    parent.add_relationship(reltype, color, weight=1.0)
+    child.add_relationship(reltype, color, weight=0.55)
+
+    mod = ModuleRemoveRedundancy()
+    mod.set_uks(uks)
+    mod.is_enabled = True
+    mod.do_the_work()
+
+    assert uks.get_relationship("child", "has-color", "red") is None

--- a/python-port/tests/test_module_stress_test.py
+++ b/python-port/tests/test_module_stress_test.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+# Add python-port to sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules.module_stress_test import ModuleStressTest
+from uks import UKS, ThingLabels, transient_relationships
+
+
+def test_add_many_test_items_inserts_hierarchy():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    mod = ModuleStressTest()
+    mod.set_uks(uks)
+    message = mod.add_many_test_items(10)
+    assert message == "Items added successfully."
+    # At least 10 things should have been created
+    assert len(uks.UKSList) >= 10
+    # Verify hierarchical names exist
+    assert uks.labeled("A0") is not None
+    assert uks.labeled("B00") is not None
+    assert uks.labeled("C000") is not None
+
+
+def test_add_many_test_items_invalid_counts():
+    uks = UKS()
+    mod = ModuleStressTest()
+    mod.set_uks(uks)
+    assert "cannot commence" in mod.add_many_test_items(0)
+    assert "cannot commence" in mod.add_many_test_items(100001)

--- a/python-port/tests/test_network.py
+++ b/python-port/tests/test_network.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import socket
+import threading
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from network import udp_send
+
+
+def test_udp_send_local():
+    recv_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    recv_sock.bind(("127.0.0.1", 0))
+    port = recv_sock.getsockname()[1]
+    messages = []
+
+    def receiver():
+        data, _ = recv_sock.recvfrom(1024)
+        messages.append(data.decode())
+
+    t = threading.Thread(target=receiver)
+    t.start()
+    udp_send("hello", "127.0.0.1", port)
+    t.join(timeout=1)
+    recv_sock.close()
+    assert messages == ["hello"]

--- a/python-port/tests/test_neural_network.py
+++ b/python-port/tests/test_neural_network.py
@@ -1,0 +1,154 @@
+import sys
+import time
+from pathlib import Path
+import sys
+import time
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from network import Network
+
+
+def test_simple_propagation():
+    net = Network()
+    net.add_neuron("a")
+    net.add_neuron("b")
+    net.connect("a", "b", 0.5)
+    net.set_input("a", 1.0)
+    net.step()
+    assert net.neurons["b"].value == 0.5
+
+
+def test_simultaneous_update():
+    net = Network()
+    net.add_neuron("a")
+    net.add_neuron("b")
+    net.connect("a", "b", 1.0)
+    net.connect("b", "a", 1.0)
+    net.set_input("a", 1.0)
+    net.set_input("b", 0.0)
+    net.step()
+    assert net.neurons["b"].value == 1.0
+    assert net.neurons["a"].value == 0.0
+
+
+def test_layered_step():
+    net = Network()
+    net.add_neuron("a", layer=0)
+    net.add_neuron("b", layer=1)
+    net.add_neuron("c", layer=2)
+    net.connect("a", "b", 1.0)
+    net.connect("b", "c", 1.0)
+    net.set_input("a", 1.0)
+    net.step()
+    assert net.neurons["b"].value == 1.0
+    assert net.neurons["c"].value == 1.0
+
+
+def test_async_run_and_stop():
+    net = Network()
+    net.add_neuron("a")
+    net.add_neuron("b")
+    net.connect("a", "b", 1.0)
+    net.set_input("a", 1.0)
+    net.run(tick_rate=100)
+    try:
+        time.sleep(0.05)
+    finally:
+        net.stop()
+    assert net.neurons["b"].value == 1.0
+
+
+def test_hebbian_learning():
+    net = Network()
+    net.add_neuron("a")
+    net.add_neuron("b")
+    net.connect("a", "b", weight=0.5, learning_rate=0.1)
+    net.set_input("a", 1.0)
+    net.step()
+    syn = net._incoming["b"][0]
+    assert syn.weight == pytest.approx(0.55)
+
+
+def test_inhibitory_neuron():
+    net = Network()
+    net.add_neuron("a", kind="inhibitory")
+    net.add_neuron("b")
+    net.connect("a", "b", 1.0)
+    net.set_input("a", 1.0)
+    net.step()
+    assert net.neurons["b"].value == -1.0
+
+
+def test_global_clock_and_tick():
+    net = Network()
+    net.add_neuron("a")
+    net.step(0.05)
+    net.step(0.05)
+    assert net.time == pytest.approx(0.1)
+
+
+def test_pause_and_resume():
+    net = Network()
+    net.add_neuron("a")
+    net.add_neuron("b")
+    net.connect("a", "b", 1.0)
+    net.set_input("a", 1.0)
+    net.run(tick_rate=50)
+    try:
+        time.sleep(0.05)
+        net.pause()
+        val = net.neurons["b"].value
+        time.sleep(0.05)
+        assert net.neurons["b"].value == val
+        net.resume()
+        time.sleep(0.05)
+    finally:
+        net.stop()
+    assert net.neurons["b"].value >= 1.0
+
+
+def test_stdp_learning():
+    net = Network()
+    net.add_neuron("a")  # pre
+    net.add_neuron("b")  # post
+    net.add_neuron("drive")  # external driver for b
+    net.connect("drive", "b", 1.0)
+    syn = net.connect("a", "b", weight=0.5, stdp_rate=0.1, stdp_tau=1.0)
+    # pre fires before post
+    net.set_input("a", 1.0)
+    net.set_input("drive", 0.0)
+    net.step(0.1)  # a fires, b should not
+    net.set_input("a", 0.0)
+    net.set_input("drive", 1.0)
+    net.step(0.1)  # b fires due to driver
+    w1 = syn.weight
+    assert w1 > 0.5
+    # post before pre
+    net.set_input("drive", 1.0)
+    net.set_input("a", 0.0)
+    net.step(0.1)  # b fires first
+    net.set_input("drive", 0.0)
+    net.set_input("a", 1.0)
+    net.step(0.1)  # a fires later
+    assert syn.weight < w1
+
+
+def test_spiking_neuron_with_refractory():
+    net = Network()
+    net.add_neuron("input")
+    net.add_neuron("spike", kind="spiking", spike_threshold=0.5, refractory=0.2)
+    net.connect("input", "spike", 1.0)
+    net.set_input("input", 1.0)
+    net.step(0.1)
+    assert net.neurons["spike"].value == 1.0
+    net.set_input("input", 1.0)
+    net.step(0.1)
+    assert net.neurons["spike"].value == 0.0
+    net.set_input("input", 0.0)
+    net.step(0.2)
+    net.set_input("input", 1.0)
+    net.step(0.1)
+    assert net.neurons["spike"].value == 1.0

--- a/python-port/tests/test_uks.py
+++ b/python-port/tests/test_uks.py
@@ -1,0 +1,91 @@
+import time
+import sys
+from pathlib import Path
+
+# Allow importing modules from the python-port directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from uks import UKS, Thing, ThingLabels, transient_relationships
+
+
+def test_parent_child_and_ancestors():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    parent = uks.get_or_add_thing("animal")
+    child = uks.get_or_add_thing("dog")
+    child.add_parent(parent)
+    assert child.Parents == [parent]
+    assert parent.Children == [child]
+    assert child.AncestorList() == [parent]
+
+
+def test_transient_relationship_expiry():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    a = uks.get_or_add_thing("a")
+    b = uks.get_or_add_thing("b")
+    reltype = uks.get_or_add_thing("has-property")
+    a.add_relationship(reltype, b, ttl=0.2)
+    assert transient_relationships  # relationship registered
+    time.sleep(0.5)
+    uks.remove_expired_relationships()
+    assert not transient_relationships
+    assert not a.relationships
+
+
+def test_add_statement_and_get_relationship():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    rel = uks.add_statement("cat", "is-a", "animal")
+    fetched = uks.get_relationship("cat", "is-a", "animal")
+    assert rel is fetched
+    rel2 = uks.add_statement("cat", "is-a", "animal")
+    assert rel2 is rel
+
+
+def test_persistence_and_query(tmp_path):
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    uks.add_relationship("a", "likes", "b", weight=0.7)
+    path = tmp_path / "uks.json"
+    uks.save(str(path))
+    uks2 = UKS()
+    uks2.load(str(path))
+    rels = uks2.query(source="a", reltype="likes", min_weight=0.5)
+    assert len(rels) == 1
+
+
+def test_event_hooks_and_conflict_resolution():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    added = []
+    updated = []
+    removed = []
+    uks.on("add", lambda r: added.append(r))
+    uks.on("update", lambda r: updated.append(r))
+    uks.on("remove", lambda r: removed.append(r))
+
+    rel = uks.add_relationship("a", "likes", "b", weight=0.1)
+    assert added and not updated
+    rel2 = uks.add_relationship("a", "likes", "b", weight=0.5)
+    assert rel2 is rel
+    assert updated and rel.weight == 0.5
+    uks.remove_relationship(rel)
+    assert removed
+
+
+def test_label_autoincrement():
+    ThingLabels.clear_label_list()
+    transient_relationships.clear()
+    uks = UKS()
+    a = uks.add_thing("node", None)
+    b = uks.add_thing("node", None)
+    c = uks.add_thing("node*", None)
+    assert a.Label == "node"
+    assert b.Label == "node0"
+    assert c.Label == "node1"

--- a/python-port/tests/test_utils.py
+++ b/python-port/tests/test_utils.py
@@ -1,0 +1,87 @@
+import sys
+import math
+import threading
+from pathlib import Path
+
+
+# Allow importing modules from the python-port directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils
+from angle import Angle
+
+
+def test_round_to_significant_digits():
+    assert utils.round_to_significant_digits(123.456, 2) == 120.0
+
+
+def test_color_conversion():
+    color_int = utils.color_to_int(1, 2, 3)
+    assert utils.int_to_color(color_int) == (1, 2, 3)
+
+
+def test_build_and_parse_filename(tmp_path):
+    fn = utils.build_annotated_image_file_name(
+        folder=str(tmp_path),
+        delta_turn=Angle.from_degrees(5),
+        delta_move=1.0,
+        camera_pan=Angle.from_degrees(2),
+        camera_tilt=Angle.from_degrees(3),
+        extension="jpg",
+    )
+    assert utils.image_has_movement(fn)
+    assert utils.get_turn_delta_from_annotated_image_file_name(fn).degrees == 5
+    assert utils.get_move_delta_from_annotated_image_file_name(fn) == 1.0
+    assert utils.get_camera_pan_from_annotated_image_file_name(fn).degrees == 2
+    assert utils.get_camera_tilt_from_annotated_image_file_name(fn).degrees == 3
+
+    fn2 = utils.build_annotated_image_file_name(
+        str(tmp_path),
+        Angle.from_degrees(0),
+        0.0,
+        Angle.from_degrees(0),
+        Angle.from_degrees(0),
+        "jpg",
+    )
+    assert not utils.image_has_movement(fn2)
+
+
+def test_find_first_and_find_all():
+    data = [1, 2, 3, 4, 5]
+    assert utils.find_first(data, lambda x: x > 3) == 4
+    assert utils.find_first(data, lambda x: x > 10) is None
+    assert utils.find_all(data, lambda x: x % 2 == 0) == [2, 4]
+
+
+def test_rad():
+    assert math.isclose(utils.rad(180), math.pi)
+
+
+def test_angle_comparisons_and_hashing():
+    a = Angle.from_degrees(45)
+    b = Angle.from_degrees(90)
+    assert a < b
+    assert b > a
+    assert a == Angle.from_degrees(45)
+    # hashing and ordering
+    s = {a, Angle.from_degrees(45)}
+    assert len(s) == 1
+    assert list(sorted([b, a])) == [a, b]
+
+
+def test_new_track_id_thread_safe():
+    utils.reset_track_id()
+    ids: list[str] = []
+
+    def worker(count: int) -> None:
+        for _ in range(count):
+            ids.append(utils.new_track_id())
+
+    threads = [threading.Thread(target=worker, args=(100,)) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(ids) == 500
+    assert len(set(ids)) == 500

--- a/python-port/uks/__init__.py
+++ b/python-port/uks/__init__.py
@@ -1,0 +1,12 @@
+"""Python port of the Universal Knowledge Store (UKS).
+
+The module exposes :class:`Thing`, :class:`Relationship`, and :class:`UKS`
+classes closely mirroring their counterparts in the original C# project.
+"""
+
+from .relationship import Relationship
+from .thing import Thing, transient_relationships
+from .thing_labels import ThingLabels
+from .uks import UKS
+
+__all__ = ["Thing", "Relationship", "ThingLabels", "UKS", "transient_relationships"]

--- a/python-port/uks/relationship.py
+++ b/python-port/uks/relationship.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""UKS relationship objects.
+
+Relationships connect a *source* Thing to a *target* Thing via a *reltype*
+Thing which describes the kind of relationship.  They may optionally expire
+after ``time_to_live`` seconds and keep track of the last time they were
+accessed via ``last_used``.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+@dataclass
+class Relationship:
+    source: "Thing"
+    reltype: "Thing"
+    target: Optional["Thing"]
+    weight: float = 1.0
+    time_to_live: timedelta = timedelta.max
+    last_used: datetime = field(default_factory=datetime.now)
+    misses: int = 0
+
+    def touch(self) -> None:
+        """Update the ``last_used`` timestamp to now."""
+        self.last_used = datetime.now()

--- a/python-port/uks/thing.py
+++ b/python-port/uks/thing.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""Thing class representing nodes in the Universal Knowledge Store."""
+
+from datetime import timedelta
+from typing import List, Optional
+
+from .relationship import Relationship
+from .thing_labels import ThingLabels
+
+# Registry of transient relationships used by UKS timers
+transient_relationships: List[Relationship] = []
+
+
+class Thing:
+    def __init__(self, label: str, value: Optional[object] = None):
+        self._label = ""
+        self.V = value
+        self.relationships: List[Relationship] = []
+        self.relationships_from: List[Relationship] = []
+        self.relationships_as_type: List[Relationship] = []
+        self.Label = label
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return self.ToString()
+
+    # ------------------------------------------------------------------
+    # String utilities
+    # ------------------------------------------------------------------
+    def ToString(self, show_properties: bool = False) -> str:
+        ret = self.Label
+        if self.V is not None:
+            ret += f" V: {self.V}"
+        if show_properties and self.relationships:
+            ret += " {" + ",".join(r.target.Label if r.target else "" for r in self.relationships) + "}"
+        return ret
+
+    # ------------------------------------------------------------------
+    # Label management
+    # ------------------------------------------------------------------
+    @property
+    def Label(self) -> str:
+        return self._label
+
+    @Label.setter
+    def Label(self, value: str) -> None:
+        if value == self._label:
+            return
+        self._label = ThingLabels.add_thing_label(value, self)
+
+    # ------------------------------------------------------------------
+    # Relationship management
+    # ------------------------------------------------------------------
+    def add_relationship(
+        self,
+        reltype: "Thing",
+        target: Optional["Thing"],
+        ttl: Optional[float] = None,
+        weight: float = 1.0,
+    ) -> Relationship:
+        """Create and register a new relationship from this Thing.
+
+        Parameters
+        ----------
+        reltype:
+            The relationship type Thing.
+        target:
+            The target Thing or ``None`` for property-only relationships.
+        ttl:
+            Optional time-to-live in seconds.  When provided the relationship is
+            added to :data:`transient_relationships` for automatic expiry.
+        weight:
+            Strength of the relationship.  Used by some modules to adjust
+            confidence levels.
+        """
+        ttl_td = timedelta(seconds=ttl) if ttl is not None else timedelta.max
+        rel = Relationship(self, reltype, target, weight, ttl_td)
+        self.relationships.append(rel)
+        if target is not None:
+            target.relationships_from.append(rel)
+        reltype.relationships_as_type.append(rel)
+        if ttl is not None:
+            transient_relationships.append(rel)
+        return rel
+
+    def add_parent(self, parent: "Thing") -> Relationship:
+        has_child = ThingLabels.get_thing("has-child")
+        if has_child is None:
+            raise ValueError("Relationship type 'has-child' not found")
+        return parent.add_relationship(has_child, self)
+
+    def remove_parent(self, parent: "Thing") -> None:
+        """Detach *parent* from this Thing if present."""
+        has_child = ThingLabels.get_thing("has-child")
+        for rel in list(parent.relationships):
+            if rel.reltype == has_child and rel.target is self:
+                parent.remove_relationship(rel)
+                break
+
+    def remove_relationship(self, rel: Relationship) -> None:
+        if rel in self.relationships:
+            self.relationships.remove(rel)
+        if rel.target and rel in rel.target.relationships_from:
+            rel.target.relationships_from.remove(rel)
+        if rel in rel.reltype.relationships_as_type:
+            rel.reltype.relationships_as_type.remove(rel)
+        if rel in transient_relationships:
+            transient_relationships.remove(rel)
+
+    # ------------------------------------------------------------------
+    # Relationship queries
+    # ------------------------------------------------------------------
+    @property
+    def Parents(self) -> List["Thing"]:
+        has_child = ThingLabels.get_thing("has-child")
+        return [r.source for r in self.relationships_from if r.reltype == has_child and r.target is self]
+
+    @property
+    def Children(self) -> List["Thing"]:
+        has_child = ThingLabels.get_thing("has-child")
+        return [r.target for r in self.relationships if r.reltype == has_child and r.target is not None]
+
+    @property
+    def ChildrenWithSubclasses(self) -> List["Thing"]:
+        """Return direct children expanding any instance subclasses.
+
+        A child whose label starts with this Thing's label is treated as an
+        instance/subclass.  In that case its own children are included instead
+        of the child itself, mirroring the behaviour of the C# implementation.
+        """
+
+        children = self.Children[:]
+        i = 0
+        while i < len(children):
+            c = children[i]
+            if c.Label.startswith(self.Label):
+                children.extend(c.Children)
+                children.pop(i)
+                continue
+            i += 1
+        return children
+
+    def AncestorList(self) -> List["Thing"]:
+        result: List[Thing] = []
+        stack = list(self.Parents)
+        while stack:
+            parent = stack.pop()
+            if parent not in result:
+                result.append(parent)
+                stack.extend(parent.Parents)
+        return result
+
+    def Descendents(self) -> List["Thing"]:
+        result: List[Thing] = []
+        stack = list(self.Children)
+        while stack:
+            child = stack.pop()
+            if child not in result:
+                result.append(child)
+                stack.extend(child.Children)
+        return result
+
+    def has_ancestor(self, label: str) -> bool:
+        """Return ``True`` if any ancestor has the given *label*."""
+        return any(t.Label == label for t in self.AncestorList())
+
+    def has_ancestor_labeled(self, label: str) -> bool:
+        """Case-insensitive label lookup for ancestor relationships."""
+        return self.has_ancestor(label)
+
+    # ------------------------------------------------------------------
+    # Attribute and property helpers
+    # ------------------------------------------------------------------
+    def get_attributes(self) -> List["Thing"]:
+        ret: List[Thing] = []
+        for r in self.relationships:
+            if r.reltype.Label.lower() in {"hasattribute", "is"} and r.target:
+                ret.append(r.target)
+        return ret
+
+    def set_attribute(self, attribute_value: "Thing") -> Relationship:
+        reltype = ThingLabels.get_thing("hasAttribute")
+        if reltype is None:
+            reltype = Thing("hasAttribute")
+        return self.add_relationship(reltype, attribute_value)
+
+    def has_property(self, t: "Thing") -> bool:
+        for r in self.relationships:
+            if r.reltype.Label.lower() == "hasproperty" and r.target is t:
+                return True
+        for parent in self.Parents:
+            if parent.has_property(t):
+                return True
+        return False

--- a/python-port/uks/thing_labels.py
+++ b/python-port/uks/thing_labels.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Mapping between Thing labels and objects.
+
+This mirrors the C# `ThingLabels` static helper which keeps a global
+case-insensitive dictionary of all created `Thing` instances. Labels are
+stored case-insensitively but the original casing is preserved on the
+`Thing` instances themselves.
+"""
+
+from typing import Dict, Optional
+
+
+class ThingLabels:
+    _labels: Dict[str, "Thing"] = {}
+
+    @classmethod
+    def add_thing_label(cls, label: str, thing: "Thing") -> str:
+        """Associate *label* with *thing*, auto-incrementing on collisions.
+
+        Mimics the behaviour of the C# implementation which automatically
+        appends digits when a label already exists.  A trailing ``"*"`` forces
+        numbering to start at 0.  Any previous label mapped to ``thing`` is
+        removed before assignment.
+        """
+
+        if label == "":
+            return label
+
+        # Remove any previous label associated with this Thing
+        old = getattr(thing, "_label", "")
+        if old:
+            cls._labels.pop(old.lower(), None)
+
+        base = label
+        cur = -1
+        if label.endswith("*"):
+            base = label[:-1]
+            cur = 0
+            label = f"{base}{cur}"
+
+        while True:
+            key = label.lower()
+            existing = cls._labels.get(key)
+            if existing is None or existing is thing:
+                cls._labels[key] = thing
+                return label
+            cur += 1
+            label = f"{base}{cur}"
+
+    @classmethod
+    def get_thing(cls, label: str) -> Optional["Thing"]:
+        return cls._labels.get(label.lower())
+
+    @classmethod
+    def remove_thing_label(cls, label: str) -> None:
+        cls._labels.pop(label.lower(), None)
+
+    @classmethod
+    def clear_label_list(cls) -> None:
+        cls._labels.clear()

--- a/python-port/uks/uks.py
+++ b/python-port/uks/uks.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+"""Universal Knowledge Store main interface."""
+
+from datetime import datetime, timedelta
+import json
+import threading
+from typing import Callable, Dict, List, Optional
+
+from .thing import Thing, transient_relationships
+from .relationship import Relationship
+from .thing_labels import ThingLabels
+
+
+class UKS:
+    """Container for all Things and Relationships.
+
+    This is a partial port of the C# UKS class.  It maintains a global list of
+    Things and periodically removes transient relationships whose TTL has
+    expired.
+    """
+
+    def __init__(self) -> None:
+        # initialise UKS list only once
+        if not ThingLabels.get_thing("has-child"):
+            ThingLabels.clear_label_list()
+            self.UKSList: List[Thing] = []
+            self.create_initial_structure()
+        else:
+            # Reuse existing list if UKS already initialised
+            self.UKSList = [t for t in ThingLabels._labels.values()]
+
+        # event handlers for relationship changes
+        self._handlers: Dict[str, List[Callable[[Relationship], None]]] = {}
+
+        # Start background thread for TTL processing
+        self._stop_event = threading.Event()
+        thread = threading.Thread(target=self._timer_loop, daemon=True)
+        thread.start()
+
+    # ------------------------------------------------------------------
+    # Initialization helpers
+    # ------------------------------------------------------------------
+    def create_initial_structure(self) -> None:
+        # Minimal structure: root thing and required relationship types
+        root = self.add_thing("Object", None)
+        has_child = self.add_thing("has-child", None)
+        unknown = self.add_thing("unknownObject", root)
+        # The above ensures parent/child relations are supported
+
+    # ------------------------------------------------------------------
+    # Timer loop handling transient relationships
+    # ------------------------------------------------------------------
+    def _timer_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self.remove_expired_relationships()
+            self._stop_event.wait(1.0)
+
+    def remove_expired_relationships(self) -> None:
+        now = datetime.now()
+        for rel in list(transient_relationships):
+            if rel.time_to_live != timedelta.max and rel.last_used + rel.time_to_live < now:
+                self.remove_relationship(rel)
+
+    # ------------------------------------------------------------------
+    # Thing management
+    # ------------------------------------------------------------------
+    def add_thing(self, label: str, parent: Optional[Thing]) -> Thing:
+        thing = Thing(label)
+        if parent is not None:
+            thing.add_parent(parent)
+        self.UKSList.append(thing)
+        return thing
+
+    def get_or_add_thing(self, label: str, parent: Optional[Thing] = None, value: Optional[object] = None) -> Thing:
+        t = ThingLabels.get_thing(label)
+        if t is None:
+            t = Thing(label, value)
+            self.UKSList.append(t)
+            if parent is not None:
+                t.add_parent(parent)
+        return t
+
+    def labeled(self, label: str) -> Optional[Thing]:
+        return ThingLabels.get_thing(label)
+
+    def delete_thing(self, thing: Thing) -> None:
+        for rel in list(thing.relationships):
+            thing.remove_relationship(rel)
+        for rel in list(thing.relationships_from):
+            rel.source.remove_relationship(rel)
+        ThingLabels.remove_thing_label(thing.Label)
+        if thing in self.UKSList:
+            self.UKSList.remove(thing)
+
+    # ------------------------------------------------------------------
+    # Relationship helpers
+    # ------------------------------------------------------------------
+    def add_relationship(
+        self,
+        source: str | Thing,
+        reltype: str | Thing,
+        target: Optional[str | Thing],
+        ttl: Optional[float] = None,
+        weight: float = 1.0,
+    ) -> Relationship:
+        s = self._thing_from_param(source)
+        rt = self._thing_from_param(reltype)
+        t = self._thing_from_param(target) if target is not None else None
+
+        existing = self.get_relationship(s, rt, t)
+        if existing is not None:
+            if weight > existing.weight:
+                existing.weight = weight
+            if ttl is not None:
+                existing.time_to_live = timedelta(seconds=ttl)
+                existing.last_used = datetime.now()
+            self._fire("update", existing)
+            return existing
+
+        rel = s.add_relationship(rt, t, ttl, weight)
+        self._fire("add", rel)
+        return rel
+
+    def get_relationship(
+        self,
+        source: str | Thing,
+        reltype: str | Thing,
+        target: Optional[str | Thing] = None,
+    ) -> Optional[Relationship]:
+        """Return an existing relationship matching the given parameters.
+
+        Parameters accept either :class:`Thing` instances or labels.  If a
+        label is provided and no corresponding :class:`Thing` exists the
+        method returns ``None`` without creating new Things.  This mirrors the
+        behaviour of the C# ``GetRelationship`` helper used throughout the
+        project.
+        """
+
+        s = source if isinstance(source, Thing) else ThingLabels.get_thing(source)
+        rt = reltype if isinstance(reltype, Thing) else ThingLabels.get_thing(reltype)
+        t = (
+            target
+            if isinstance(target, Thing)
+            else ThingLabels.get_thing(target) if target is not None else None
+        )
+        if s is None or rt is None:
+            return None
+        for rel in s.relationships:
+            if rel.reltype is rt and rel.target is t:
+                return rel
+        return None
+
+    def add_statement(
+        self,
+        source: str | Thing,
+        reltype: str | Thing,
+        target: Optional[str | Thing],
+        ttl: Optional[float] = None,
+        weight: float = 1.0,
+    ) -> Relationship:
+        """Create a relationship if one does not already exist.
+
+        This is a light‑weight analogue of the C# ``AddStatement`` method.  It
+        performs basic Thing lookup/creation and ensures duplicate statements
+        are not produced.
+        """
+
+        s = self._thing_from_param(source)
+        rt = self._thing_from_param(reltype)
+        t = self._thing_from_param(target) if target is not None else None
+
+        existing = self.get_relationship(s, rt, t)
+        if existing is not None:
+            if weight > existing.weight:
+                existing.weight = weight
+            return existing
+
+        rel = s.add_relationship(rt, t, ttl, weight)
+        self._fire("add", rel)
+        return rel
+
+    def get_all_relationships(self, sources: List[Thing], reverse: bool) -> List[Relationship]:
+        """Return relationships from ``sources`` including inherited ones."""
+        result: List[Relationship] = []
+        stack = list(sources)
+        visited: set[Thing] = set()
+        while stack:
+            t = stack.pop()
+            if t in visited:
+                continue
+            visited.add(t)
+            result.extend(t.relationships)
+            stack.extend(t.Children if reverse else t.Parents)
+        return result
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self, path: str) -> None:
+        data = {
+            "things": [
+                {"label": t.Label, "value": t.V}
+                for t in self.UKSList
+            ],
+            "relationships": [
+                {
+                    "source": r.source.Label,
+                    "reltype": r.reltype.Label,
+                    "target": r.target.Label if r.target else None,
+                    "weight": r.weight,
+                    "ttl": None if r.time_to_live == timedelta.max else r.time_to_live.total_seconds(),
+                }
+                for t in self.UKSList for r in t.relationships
+            ],
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def load(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        ThingLabels.clear_label_list()
+        transient_relationships.clear()
+        self.UKSList = []
+        mapping: Dict[str, Thing] = {}
+        for td in data.get("things", []):
+            t = Thing(td["label"], td.get("value"))
+            self.UKSList.append(t)
+            mapping[t.Label] = t
+        for rd in data.get("relationships", []):
+            s = mapping[rd["source"]]
+            rt = mapping[rd["reltype"]]
+            tgt = mapping.get(rd["target"]) if rd.get("target") else None
+            ttl = rd.get("ttl")
+            s.add_relationship(rt, tgt, ttl, rd.get("weight", 1.0))
+
+    # ------------------------------------------------------------------
+    # Query API
+    # ------------------------------------------------------------------
+    def query(
+        self,
+        *,
+        source: Optional[str] = None,
+        reltype: Optional[str] = None,
+        target: Optional[str] = None,
+        min_weight: float = 0.0,
+        max_ttl: Optional[float] = None,
+    ) -> List[Relationship]:
+        """Return relationships matching the given filters."""
+
+        now = datetime.now()
+        results: List[Relationship] = []
+        for t in self.UKSList:
+            if source and t.Label != source:
+                continue
+            for r in t.relationships:
+                if reltype and r.reltype.Label != reltype:
+                    continue
+                if target and (r.target is None or r.target.Label != target):
+                    continue
+                if r.weight < min_weight:
+                    continue
+                if max_ttl is not None and r.time_to_live != timedelta.max:
+                    remaining = (r.last_used + r.time_to_live - now).total_seconds()
+                    if remaining > max_ttl:
+                        continue
+                results.append(r)
+        return results
+
+    # ------------------------------------------------------------------
+    # Event hooks
+    # ------------------------------------------------------------------
+    def on(self, event: str, callback: Callable[[Relationship], None]) -> None:
+        self._handlers.setdefault(event, []).append(callback)
+
+    def _fire(self, event: str, rel: Relationship) -> None:
+        for cb in self._handlers.get(event, []):
+            cb(rel)
+
+    def remove_relationship(self, rel: Relationship) -> None:
+        rel.source.remove_relationship(rel)
+        self._fire("remove", rel)
+
+    def _thing_from_param(self, param: str | Thing) -> Thing:
+        if isinstance(param, Thing):
+            return param
+        t = ThingLabels.get_thing(param)
+        if t is None:
+            t = self.add_thing(param, self.labeled("Object"))
+        return t

--- a/python-port/utils.py
+++ b/python-port/utils.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import datetime, os, math, threading
+from typing import Callable, Iterable, List, Optional, Tuple, TypeVar
+try:
+    from .angle import Angle
+except ImportError:
+    from angle import Angle
+
+
+T = TypeVar("T")
+
+
+def find_first(source: Iterable[T], condition: Callable[[T], bool]) -> Optional[T]:
+    """Return the first item in *source* satisfying *condition* or ``None``."""
+    for item in source:
+        if condition(item):
+            return item
+    return None
+
+
+def find_all(source: Iterable[T], condition: Callable[[T], bool]) -> List[T]:
+    """Return all items in *source* satisfying *condition*."""
+    return [item for item in source if condition(item)]
+
+
+def rad(degrees: float) -> float:
+    """Convert degrees to radians."""
+    return math.radians(degrees)
+
+
+def round_to_significant_digits(d: float, digits: int) -> float:
+    if d == 0:
+        return 0.0
+    scale = 10 ** (math.floor(math.log10(abs(d))) + 1)
+    return scale * round(d / scale, digits)
+
+
+def int_to_color(the_color: int) -> Tuple[int, int, int]:
+    return (
+        the_color >> 16 & 0xFF,
+        the_color >> 8 & 0xFF,
+        the_color & 0xFF,
+    )
+
+
+def color_to_int(r: int, g: int, b: int) -> int:
+    return (r << 16) + (g << 8) + b
+
+
+def build_annotated_image_file_name(
+    folder: str,
+    delta_turn: Angle,
+    delta_move: float,
+    camera_pan: Angle | None,
+    camera_tilt: Angle | None,
+    extension: str,
+) -> str:
+    camera_pan = camera_pan or Angle.from_degrees(0)
+    camera_tilt = camera_tilt or Angle.from_degrees(0)
+    now = datetime.datetime.now()
+    timestamp = now.strftime("%Y%m%d_%H%M%S_%f")[:-3]
+    filename = (
+        f"{timestamp}_{int(delta_turn.degrees)}_{delta_move:.1f}_"
+        f"{int(camera_pan.degrees)}_{int(camera_tilt.degrees)}_.{extension}"
+    )
+    return os.path.join(folder, filename)
+
+
+def image_has_movement(filename: str) -> bool:
+    name = os.path.splitext(os.path.basename(filename))[0]
+    parts = name.split("_")
+    if len(parts) != 8:
+        return False
+    return "_0_0.0_" not in name
+
+
+def get_turn_delta_from_annotated_image_file_name(filename: str) -> Angle:
+    parts = os.path.basename(filename).split("_")
+    if len(parts) <= 3:
+        return Angle.from_degrees(0)
+    try:
+        return Angle.from_degrees(int(parts[3]))
+    except ValueError:
+        return Angle.from_degrees(0)
+
+
+def get_move_delta_from_annotated_image_file_name(filename: str) -> float:
+    parts = os.path.basename(filename).split("_")
+    if len(parts) <= 4:
+        return 0.0
+    try:
+        return float(parts[4])
+    except ValueError:
+        return 0.0
+
+
+def get_camera_pan_from_annotated_image_file_name(filename: str) -> Angle:
+    parts = os.path.basename(filename).split("_")
+    if len(parts) <= 5:
+        return Angle.from_degrees(0)
+    try:
+        return Angle.from_degrees(int(parts[5]))
+    except ValueError:
+        return Angle.from_degrees(0)
+
+
+def get_camera_tilt_from_annotated_image_file_name(filename: str) -> Angle:
+    parts = os.path.basename(filename).split("_")
+    if len(parts) <= 6:
+        return Angle.from_degrees(0)
+    try:
+        return Angle.from_degrees(int(parts[6]))
+    except ValueError:
+        return Angle.from_degrees(0)
+
+
+_trackid = 1000
+_trackid_lock = threading.Lock()
+
+
+def new_track_id() -> str:
+    """Return a unique tracking id as a zero-padded string."""
+    global _trackid
+    with _trackid_lock:
+        _trackid += 1
+        return f"{_trackid:04d}"
+
+
+def reset_track_id(value: int = 1000) -> None:
+    """Reset the internal track id counter (for testing)."""
+    global _trackid
+    with _trackid_lock:
+        _trackid = int(value)


### PR DESCRIPTION
## Summary
- Add rich comparison and hashing to Angle for use in sorted collections
- Guard track ID generation with a lock and expose reset helper
- Test Angle ordering/hash and thread-safe ID uniqueness across threads

## Testing
- `python -m pytest python-port/tests/test_utils.py python-port/tests/test_colors.py python-port/tests/test_module_framework.py python-port/tests/test_network.py python-port/tests/test_uks.py python-port/tests/test_neural_network.py python-port/tests/test_module_remove_redundancy.py python-port/tests/test_module_add_counts.py python-port/tests/test_module_balance_tree.py python-port/tests/test_module_class_create.py python-port/tests/test_module_stress_test.py python-port/tests/test_module_attribute_bubble.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc30529c8328995498801a1e7513